### PR TITLE
fix: set EC as example

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -16,7 +16,7 @@ servers:
     description: Validated ID API 
   - url: https://dev.vidchain.net
     description: Validated ID API Dev
-  - url: https://localhost:9002
+  - url: http://localhost:9002
     description: localhost
 tags:
   - name: SSI EIDAS Bridge
@@ -25,7 +25,7 @@ paths:
   /eidas-bridge/v1/signatures:
     post:
       tags:
-        - eIDAS Bridge
+        - SSI EIDAS Bridge
       summary: Creates a JWT ES256K eIDAS eSeal signature
       description: "Creates a JWT ES256K eIDAS eSeal signature"
       operationId: post-eidas-bridge-v1-signatures
@@ -130,7 +130,7 @@ paths:
   /eidas-bridge/v1/signature-validations:
     post:
       tags:
-        - eIDAS Bridge
+        - SSI EIDAS Bridge
       summary: Validates a JWT ES256K eIDAS eSeal signature
       description: "Validates a JWT ES256K eIDAS eSeal signature"
       operationId: post-eidas-bridge-v1-signature-validations
@@ -188,7 +188,7 @@ paths:
   /eidas-bridge/v1/eidas-keys:
     put:
       tags:
-        - eIDAS Bridge
+        - SSI EIDAS Bridge
       summary: Updates the keys used to sign
       description: "Stores eidas keys used to sign"
       operationId: put-eidas-bridge-v1-eidas-keys
@@ -208,56 +208,65 @@ paths:
                 eidasKey:
                   description: hexPrivateKey for secp256k1 or PEM RSA key 
                   type: string
-                  example: |  
-                    "-----BEGIN RSA PRIVATE KEY-----
-                    MIIEpQIBAAKCAQEA3Tz2mr7SZiAMfQyuvBjM9Oi..Z1BjP5CE/Wm/Rr500P
-                    RK+Lh9x5eJPo5CAZ3/ANBE0sTK0ZsDGMak2m1g7..3VHqIxFTz0Ta1d+NAj
-                    wnLe4nOb7/eEJbDPkk05ShhBrJGBKKxb8n104o/..PdzbFMIyNjJzBM2o5y
-                    5A13wiLitEO7nco2WfyYkQzaxCw0AwzlkVHiIyC..71pSzkv6sv+4IDMbT/
-                    XpCo8L6wTarzrywnQsh+etLD6FtTjYbbrvZ8RQM..Hg2qxraAV++HNBYmNW
-                    s0duEdjUbJK+ZarypXI9TtnS4o1Ckj7POfljiQI..IBAFyidxtqRQyv5KrD
-                    kbJ+q+rsJxQlaipn2M4lGuQJEfIxELFDyd3XpxP..Un/82NZNXlPmRIopXs
-                    2T91jiLZEUKQw+n73j26adTbteuEaPGSrTZxBLR..yssO0wWomUyILqVeti
-                    6AkL0NJAuKcucHGqWVgUIa4g1haE0ilcm6dWUDo..fd+PpzdCJf1s4NdUWK
-                    YV2GJcutGQb+jqT5DTUqAgST7N8M28rwjK6nVMI..BUpP0xpPnuYDyPOw6x
-                    4hBt8DZQYyduzIXBXRBKNiNdv8fum68/5klHxp6..4HRkMUL958UVeljUsT
-                    BFQlO9UCgYEA/VqzXVzlz8K36VSTMPEhB5zBATV..PRiXtYK1YpYV4/jSUj
-                    vvT4hP8uoYNC+BlEMi98LtnxZIh0V4rqHDsScAq..VyeSLH0loKMZgpwFEm
-                    bEIDnEOD0nKrfT/9K9sPYgvB43wsLEtUujaYw3W..Liy0WKmB8CgYEA34xn
-                    1QlOOhHBn9Z8qYjoDYhvcj+a89tD9eMPhesfQFw..rsfGcXIonFmWdVygbe
-                    6Doihc+GIYIq/QP4jgMksE1ADvczJSke92ZfE2i..fitBpQERNJO0BlabfP
-                    ALs5NssKNmLkWS2U2BHCbv4DzDXwiQB37KPOL1c..kBHfF2/htIs20d1UVL
-                    +PK+aXKwguI6bxLGZ3of0UH+mGsSl0mkp7kYZCm..OTQtfeRqP8rDSC7DgA
-                    kHc5ajYqh04AzNFaxjRo+M3IGICUaOdKnXd0Fda..QwfoaX4QlRTgLqb7AN
-                    ZTzM9WbmnYoXrx17kZlT3lsCgYEAm757XI3WJVj..WoLj1+v48WyoxZpcai
-                    uv9bT4Cj+lXRS+gdKHK+SH7J3x2CRHVS+WH/SVC..DxuybvebDoT0TkKiCj
-                    BWQaGzCaJqZa+POHK0klvS+9ln0/6k539p95tfX..X4TCzbVG6+gJiX0ysz
-                    Yfehn5MCgYEAkMiKuWHCsVyCab3RUf6XA9gd3qY..fCTIGtS1tR5PgFIV+G
-                    engiVoWc/hkj8SBHZz1n1xLN7KDf8ySU06MDggB..hJ+gXJKy+gf3mF5Kmj
-                    DtkpjGHQzPF6vOe907y5NQLvVFGXUq/FIJZxB8k..fJdHEm2M4=
-                    -----END RSA PRIVATE KEY-----"
+                  example: "c07394b3e13e114406144d8fa4e90429a27e20131c68f070c40533a059fef51f"
                 keyType:
                   description: Specifies type of key used, i.e. "RSA", "EC" or "OKP"
                   type: string
-                  example: "RSA"
+                  example: "EC"
                 curveType:
                   description: If keyType is "EC" or "OKP", the curveType can be specified as well as "P-256", "secp256k1","P-384" or "P-521"
-                  type: Curves
+                  type: object
                   example: "secp256k1"
         required: true
       responses:
         "201":
           description: Keys stored
           content:
-            application/problem+json:
+            application/json:
               schema:
                 $ref: "#/components/schemas/EidasKey"
         "200":
           description: Keys updated
           content:
-            application/problem+json:
+            application/json:
               schema:
                 $ref: "#/components/schemas/EidasKey"
+                "400":
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+              examples:
+                Bad Request:
+                  $ref: "#/components/examples/BadRequest"
+        "401":
+          description: Unauthorized
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+              examples:
+                Unauthorized:
+                  $ref: "#/components/examples/Unauthorized"
+        "403":
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+              examples:
+                Forbidden:
+                  $ref: "#/components/examples/Forbidden"
+        "500":
+          description: Internal Server Error
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+              examples:
+                Internal Server Error:
+                  $ref: "#/components/examples/InternalError"
 components:
   schemas:
     Proof:
@@ -481,117 +490,32 @@ components:
           placeOfBirth: Brussels
           currentAddress: "44, rue de Fame"
           gender: Female
-    EidasKeysOptions:
-      description: |
-        Specifications used to sign
-      type: object
-      properties:
-        did:
-          description: Did of the signer
-          type: string
-          example: did:vid:0xB551b70d650892d23dE3Be201A95c1FcBea98A3D
-        eidasKey:
-          description: hexPrivateKey for secp256k1 or PEM RSA key 
-          type: string
-          example: |  
-            "-----BEGIN RSA PRIVATE KEY-----
-            MIIEpQIBAAKCAQEA3Tz2mr7SZiAMfQyuvBjM9Oi..Z1BjP5CE/Wm/Rr500P
-            RK+Lh9x5eJPo5CAZ3/ANBE0sTK0ZsDGMak2m1g7..3VHqIxFTz0Ta1d+NAj
-            wnLe4nOb7/eEJbDPkk05ShhBrJGBKKxb8n104o/..PdzbFMIyNjJzBM2o5y
-            5A13wiLitEO7nco2WfyYkQzaxCw0AwzlkVHiIyC..71pSzkv6sv+4IDMbT/
-            XpCo8L6wTarzrywnQsh+etLD6FtTjYbbrvZ8RQM..Hg2qxraAV++HNBYmNW
-            s0duEdjUbJK+ZarypXI9TtnS4o1Ckj7POfljiQI..IBAFyidxtqRQyv5KrD
-            kbJ+q+rsJxQlaipn2M4lGuQJEfIxELFDyd3XpxP..Un/82NZNXlPmRIopXs
-            2T91jiLZEUKQw+n73j26adTbteuEaPGSrTZxBLR..yssO0wWomUyILqVeti
-            6AkL0NJAuKcucHGqWVgUIa4g1haE0ilcm6dWUDo..fd+PpzdCJf1s4NdUWK
-            YV2GJcutGQb+jqT5DTUqAgST7N8M28rwjK6nVMI..BUpP0xpPnuYDyPOw6x
-            4hBt8DZQYyduzIXBXRBKNiNdv8fum68/5klHxp6..4HRkMUL958UVeljUsT
-            BFQlO9UCgYEA/VqzXVzlz8K36VSTMPEhB5zBATV..PRiXtYK1YpYV4/jSUj
-            vvT4hP8uoYNC+BlEMi98LtnxZIh0V4rqHDsScAq..VyeSLH0loKMZgpwFEm
-            bEIDnEOD0nKrfT/9K9sPYgvB43wsLEtUujaYw3W..Liy0WKmB8CgYEA34xn
-            1QlOOhHBn9Z8qYjoDYhvcj+a89tD9eMPhesfQFw..rsfGcXIonFmWdVygbe
-            6Doihc+GIYIq/QP4jgMksE1ADvczJSke92ZfE2i..fitBpQERNJO0BlabfP
-            ALs5NssKNmLkWS2U2BHCbv4DzDXwiQB37KPOL1c..kBHfF2/htIs20d1UVL
-            +PK+aXKwguI6bxLGZ3of0UH+mGsSl0mkp7kYZCm..OTQtfeRqP8rDSC7DgA
-            kHc5ajYqh04AzNFaxjRo+M3IGICUaOdKnXd0Fda..QwfoaX4QlRTgLqb7AN
-            ZTzM9WbmnYoXrx17kZlT3lsCgYEAm757XI3WJVj..WoLj1+v48WyoxZpcai
-            uv9bT4Cj+lXRS+gdKHK+SH7J3x2CRHVS+WH/SVC..DxuybvebDoT0TkKiCj
-            BWQaGzCaJqZa+POHK0klvS+9ln0/6k539p95tfX..X4TCzbVG6+gJiX0ysz
-            Yfehn5MCgYEAkMiKuWHCsVyCab3RUf6XA9gd3qY..fCTIGtS1tR5PgFIV+G
-            engiVoWc/hkj8SBHZz1n1xLN7KDf8ySU06MDggB..hJ+gXJKy+gf3mF5Kmj
-            DtkpjGHQzPF6vOe907y5NQLvVFGXUq/FIJZxB8k..fJdHEm2M4=
-            -----END RSA PRIVATE KEY-----"
-        keyType:
-          description: Specifies type of key used, i.e. "RSA", "EC" or "OKP"
-          type: string
-          example: "RSA"
-        curveType:
-          description: If keyType is "EC" or "OKP", the curveType can be specified as well as "P-256", "secp256k1","P-384" or "P-521"
-          type: Curves
-          example: "secp256k1"
     EidasKey:
+      title: EidasKey
+      type: string
       description: |
         hexPrivateKey for secp256k1 or PEM RSA key stored that will be used to sign.
-      type: string
-      example: |
-        "-----BEGIN RSA PRIVATE KEY-----
-        MIIEpQIBAAKCAQEA3Tz2mr7SZiAMfQyuvBjM9Oi..Z1BjP5CE/Wm/Rr500P
-        RK+Lh9x5eJPo5CAZ3/ANBE0sTK0ZsDGMak2m1g7..3VHqIxFTz0Ta1d+NAj
-        wnLe4nOb7/eEJbDPkk05ShhBrJGBKKxb8n104o/..PdzbFMIyNjJzBM2o5y
-        5A13wiLitEO7nco2WfyYkQzaxCw0AwzlkVHiIyC..71pSzkv6sv+4IDMbT/
-        XpCo8L6wTarzrywnQsh+etLD6FtTjYbbrvZ8RQM..Hg2qxraAV++HNBYmNW
-        s0duEdjUbJK+ZarypXI9TtnS4o1Ckj7POfljiQI..IBAFyidxtqRQyv5KrD
-        kbJ+q+rsJxQlaipn2M4lGuQJEfIxELFDyd3XpxP..Un/82NZNXlPmRIopXs
-        2T91jiLZEUKQw+n73j26adTbteuEaPGSrTZxBLR..yssO0wWomUyILqVeti
-        6AkL0NJAuKcucHGqWVgUIa4g1haE0ilcm6dWUDo..fd+PpzdCJf1s4NdUWK
-        YV2GJcutGQb+jqT5DTUqAgST7N8M28rwjK6nVMI..BUpP0xpPnuYDyPOw6x
-        4hBt8DZQYyduzIXBXRBKNiNdv8fum68/5klHxp6..4HRkMUL958UVeljUsT
-        BFQlO9UCgYEA/VqzXVzlz8K36VSTMPEhB5zBATV..PRiXtYK1YpYV4/jSUj
-        vvT4hP8uoYNC+BlEMi98LtnxZIh0V4rqHDsScAq..VyeSLH0loKMZgpwFEm
-        bEIDnEOD0nKrfT/9K9sPYgvB43wsLEtUujaYw3W..Liy0WKmB8CgYEA34xn
-        1QlOOhHBn9Z8qYjoDYhvcj+a89tD9eMPhesfQFw..rsfGcXIonFmWdVygbe
-        6Doihc+GIYIq/QP4jgMksE1ADvczJSke92ZfE2i..fitBpQERNJO0BlabfP
-        ALs5NssKNmLkWS2U2BHCbv4DzDXwiQB37KPOL1c..kBHfF2/htIs20d1UVL
-        +PK+aXKwguI6bxLGZ3of0UH+mGsSl0mkp7kYZCm..OTQtfeRqP8rDSC7DgA
-        kHc5ajYqh04AzNFaxjRo+M3IGICUaOdKnXd0Fda..QwfoaX4QlRTgLqb7AN
-        ZTzM9WbmnYoXrx17kZlT3lsCgYEAm757XI3WJVj..WoLj1+v48WyoxZpcai
-        uv9bT4Cj+lXRS+gdKHK+SH7J3x2CRHVS+WH/SVC..DxuybvebDoT0TkKiCj
-        BWQaGzCaJqZa+POHK0klvS+9ln0/6k539p95tfX..X4TCzbVG6+gJiX0ysz
-        Yfehn5MCgYEAkMiKuWHCsVyCab3RUf6XA9gd3qY..fCTIGtS1tR5PgFIV+G
-        engiVoWc/hkj8SBHZz1n1xLN7KDf8ySU06MDggB..hJ+gXJKy+gf3mF5Kmj
-        DtkpjGHQzPF6vOe907y5NQLvVFGXUq/FIJZxB8k..fJdHEm2M4=
-        -----END RSA PRIVATE KEY-----"
+      properties:
+        id:
+          type: string
+          description: "key used to sign"
+      example: "c07394b3e13e114406144d8fa4e90429a27e20131c68f070c40533a059fef51f"
   examples:
     BadRequest:
       value:
         title: Bad Request
         status: 400
         detail: Bad request
-    InvalidToken:
-      value:
-        title: Bad Request
-        status: 400
-        detail: Invalid token
     Unauthorized:
       value:
         title: Unauthorized
         status: 401
         detail: Unauthorized
-    IssuerNotFound:
-      value:
-        title: Issuer Not Found
-        status: 400
-        detail: Issuer not found in the list of trusted apps.
     Forbidden:
       value:
         title: Forbidden
         status: 403
         detail: Forbidden
-    ExpiredToken:
-      value:
-        title: Token Expired
-        status: 400
-        detail: The token has expired.
     InternalError:
       value:
         title: Internal Server Error


### PR DESCRIPTION
To test it locally just: 

- start the server `npm run start`
- Open [local Swagger](http://localhost:9002/eidas-bridge/v1/api-docs)
- Select localhost server
- Execute any of the three available requests

Additionally, you can test via jest added tests: `controllers.keys.spec.ts` and `controllers.nested.spec.ts`.