### PR TITLE
fix: indeterminate/400 case

### DIFF
--- a/src/api/eidas/router.ts
+++ b/src/api/eidas/router.ts
@@ -65,14 +65,6 @@ class Router {
     );
 
     router.put(
-      `${BRIDGE_SERVICE.CALL.ADD_EIDAS_KEY}`,
-      cors(),
-      (req: express.Request, res: express.Response) => {
-        res.sendStatus(400);
-      }
-    );
-
-    router.put(
       `${BRIDGE_SERVICE.CALL.ADD_EIDAS_KEY}/:id`,
       cors(),
       async (req: express.Request, res: express.Response) => {

--- a/src/api/eidas/router.ts
+++ b/src/api/eidas/router.ts
@@ -32,7 +32,7 @@ class Router {
       async (req: express.Request, res: express.Response) => {
         try {
           if (Object.keys(req.body).length === 0)
-            throw new BadRequestError(indication.VERIFICATION_INDETERMINATE, {
+            throw new BadRequestError(BadRequestError.defaultTitle, {
               detail: ApiErrorMessages.BAD_REQUEST_MISSING_BODY,
             });
           await Controller.EIDASvalidateSignature(req.body);
@@ -44,27 +44,22 @@ class Router {
           });
         } catch (error) {
           LOGGER.error(`Error ${JSON.stringify(error)}`);
-          if (
-            (error as BadRequestError).title === indication.VERIFICATION_FAIL
-          ) {
+          const errorTitle = (error as BadRequestError).title;
+          const verificationPerformed =
+            errorTitle === indication.VERIFICATION_FAIL ||
+            errorTitle === indication.VERIFICATION_INDETERMINATE;
+          if (verificationPerformed) {
             res.status(200).json({
-              indication: indication.VERIFICATION_FAIL,
+              indication:
+                errorTitle === indication.VERIFICATION_FAIL
+                  ? indication.VERIFICATION_FAIL
+                  : indication.VERIFICATION_INDETERMINATE,
               checks: ["credential", "proof"],
               warnings: [],
               errors: [JSON.stringify(error)],
             });
           }
-          if (
-            (error as BadRequestError).title ===
-            indication.VERIFICATION_INDETERMINATE
-          ) {
-            res.status(400).json({
-              indication: indication.VERIFICATION_INDETERMINATE,
-              checks: ["credential", "proof"],
-              warnings: [],
-              errors: [JSON.stringify(error)],
-            });
-          }
+          if (!verificationPerformed) res.sendStatus(400);
         }
       }
     );

--- a/src/errors/errorCodes.ts
+++ b/src/errors/errorCodes.ts
@@ -28,6 +28,7 @@ export enum ApiErrorMessages {
   SIGN_EIDAS_BAD_PARAMETERS = "Sign Eidas requires a SignPayload with issuer, payload, type and password",
   NO_EIDAS_PROOF = "Verification Credential does not contain an Eidas Proof",
   CREDENTIAL_PAYLOAD_MISMATCH_SIGNED_DATA = "Verification Credential payload does not match signed data",
+  INDETERMINATE = "The certificate chain for signature is not trusted, it does not contain a trust anchor.",
 }
 
 export default { ApiErrorMessages };


### PR DESCRIPTION
You can test this PR by means of:

1. Passing all tests of this repository ```yarn test``` (remember it requires having redis docker up)
2. Running this server ```yarn run start:dev``` and passing recently updated tests implemented in [SSI eIDAS Bridge Interoperability](https://gitlab.grnet.gr/essif-lab/interoperability/ssi-eidas-bridge/-/tree/vid-tests-suite-import-creation). To do so, clone this last, first move to ```vid-tests-suite-import-creation``` branch (where tests are implemented pending to approve).  Notice that for testing locally you will need to prepare SSI eIDAS Bridge Interoperability repo:

-  You have to set local env in participants/validatedid/index.js
```eidas_api_base_url: 'http://127.0.0.1:9002/eidas-bridge'```

- We're only concerned on running the tests for validatedID. Then, comment out "offblocks" in participants/index.js:

```
const participants = {
    // offblocks,
    validatedid,
};
```
Finally,  run ```npm run test```. 

The expected outputs for each step are: 

1.  To pass all tests in our (this) repository
2. To pass all tests except one in SSI eIDAS Bridge Interoperability repository. The case failing should be INDETERMINATE verification case which is not implemented in the server side since there's still no connection to DSS so there's no QEC discrimination.