### PR TITLE
refactor: sendStatus 400 /signatures

### DIFF
--- a/src/api/eidas/router.ts
+++ b/src/api/eidas/router.ts
@@ -16,12 +16,13 @@ class Router {
     router.post(
       `${BRIDGE_SERVICE.CALL.SIGNATURE_CREATION}`,
       cors(),
-      async (req: express.Request, res: express.Response, next) => {
+      async (req: express.Request, res: express.Response) => {
         try {
           const result = await Controller.EIDASsignature(req.body);
           res.status(201).json(result);
         } catch (error) {
-          next(error);
+          LOGGER.error(`Error ${JSON.stringify(error)}`);
+          res.sendStatus(400);
         }
       }
     );


### PR DESCRIPTION
Minor change to handle 400 in /signatures as done in /signature-validations and /eidas-keys endpoints. This change fixes test "Signature fails: should return 400 when passed an invalid issuer did" in essiflab interop test suite.